### PR TITLE
Grant metadata + new token system

### DIFF
--- a/internal/token/salt.go
+++ b/internal/token/salt.go
@@ -1,0 +1,24 @@
+//go:build seed
+
+package main
+
+import (
+	"crypto/rand"
+	"fmt"
+	"io"
+)
+
+func main() {
+	salt := make([]byte, 32)
+	if _, err := io.ReadFull(rand.Reader, salt); err != nil {
+		panic(err)
+	}
+	fmt.Print("[]byte{")
+	for i, b := range salt {
+		if i > 0 {
+			fmt.Print(", ")
+		}
+		fmt.Printf("%d", b)
+	}
+	fmt.Println("}")
+}

--- a/internal/token/token.go
+++ b/internal/token/token.go
@@ -1,0 +1,147 @@
+package token
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/hkdf"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"io"
+)
+
+var (
+	// these were generated with salt.go. we use fixed salts to domain separate
+	// key derivation from tokens.
+	encSalt    = []byte{4, 50, 41, 133, 73, 226, 110, 54, 6, 66, 16, 110, 19, 220, 42, 77, 247, 197, 203, 135, 83, 136, 72, 116, 39, 173, 26, 144, 215, 47, 234, 71}
+	storedSalt = []byte{65, 2, 216, 144, 128, 170, 60, 8, 133, 174, 56, 168, 86, 87, 200, 184, 244, 39, 252, 45, 194, 114, 212, 236, 142, 241, 64, 71, 34, 106, 209, 42}
+
+	keyLength = 32
+)
+
+// Token represents a single token issued in the system.
+type Token struct {
+	// User is the value that is exposed to the user.
+	user string
+	// Stored is the value that should be stored in the datastore. It can be
+	// looked up one-way by the user token.
+	stored []byte
+	// Encryption is an encryption key bound to this token. It can be generated
+	// from the user token, but not from the stored token or any other source.
+	// Suitable for AES-256.
+	encryption []byte
+}
+
+// User returns the value that should be exposed and used by the user.
+func (t Token) User() string {
+	return t.user
+}
+
+// Stored returns the value that should be stored in the datastore, for lookups.
+func (t Token) Stored() []byte {
+	return t.stored
+}
+
+// New creates a new token.
+func New(usage string) Token {
+	var tok = make([]byte, 32)
+	if n, err := io.ReadFull(rand.Reader, tok); err != nil || n != 32 {
+		panic(fmt.Sprintf("failed to generate random token: %v", err))
+	}
+
+	stored, err := hkdf.Key(sha256.New, tok, storedSalt, usage, keyLength)
+	if err != nil {
+		panic(fmt.Sprintf("failed to generate stored token: %v", err))
+	}
+
+	encryption, err := hkdf.Key(sha256.New, tok, encSalt, usage, keyLength)
+	if err != nil {
+		panic(fmt.Sprintf("failed to generate encryption key: %v", err))
+	}
+
+	return Token{
+		user:       base64.URLEncoding.EncodeToString(tok),
+		stored:     stored,
+		encryption: encryption,
+	}
+}
+
+// FromUserToken creates a Token struct from a user token string.
+func FromUserToken(userToken, usage string) (Token, error) {
+	user, err := base64.URLEncoding.DecodeString(userToken)
+	if err != nil {
+		return Token{}, fmt.Errorf("failed to decode user token: %v", err)
+	}
+
+	stored, err := hkdf.Key(sha256.New, user, storedSalt, usage, keyLength)
+	if err != nil {
+		return Token{}, fmt.Errorf("failed to generate stored token: %v", err)
+	}
+
+	encryption, err := hkdf.Key(sha256.New, user, encSalt, usage, keyLength)
+	if err != nil {
+		return Token{}, fmt.Errorf("failed to generate encryption key: %v", err)
+	}
+
+	return Token{
+		user:       userToken,
+		stored:     stored,
+		encryption: encryption,
+	}, nil
+}
+
+// Encrypt encrypts the plaintext with this token's encryption key.
+func (t *Token) Encrypt(plaintext, additionalData string) ([]byte, error) {
+	if len(t.encryption) != keyLength {
+		return nil, fmt.Errorf("encryption key is not the correct length")
+	}
+
+	block, err := aes.NewCipher(t.encryption)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create cipher: %v", err)
+	}
+
+	aead, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create GCM: %v", err)
+	}
+
+	nonce := make([]byte, aead.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, fmt.Errorf("failed to generate nonce: %v", err)
+	}
+
+	ciphertext := aead.Seal(nil, nonce, []byte(plaintext), []byte(additionalData))
+
+	result := append(nonce, ciphertext...)
+	return result, nil
+}
+
+// Decrypt decrypts the ciphertext with this token's encryption key.
+func (t *Token) Decrypt(ciphertext []byte, additionalData string) ([]byte, error) {
+	if len(t.encryption) != keyLength {
+		return nil, fmt.Errorf("encryption key is not the correct length")
+	}
+
+	if len(ciphertext) < 12 {
+		return nil, fmt.Errorf("ciphertext is too short")
+	}
+	nonce := ciphertext[:12]
+	enc := ciphertext[12:]
+
+	block, err := aes.NewCipher(t.encryption)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create cipher: %v", err)
+	}
+	aead, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create GCM: %v", err)
+	}
+
+	plain, err := aead.Open(nil, nonce, enc, []byte(additionalData))
+	if err != nil {
+		return nil, fmt.Errorf("failed to open ciphertext: %v", err)
+	}
+	return plain, nil
+}

--- a/internal/token/token_test.go
+++ b/internal/token/token_test.go
@@ -1,0 +1,482 @@
+package token
+
+import (
+	"encoding/base64"
+	"testing"
+)
+
+func TestTokenWorkflows(t *testing.T) {
+	tests := []struct {
+		name           string
+		plaintext      string
+		additionalData string
+		usage          string
+	}{
+		{
+			name:           "simple text",
+			plaintext:      "hello world",
+			additionalData: "grant123",
+			usage:          "access_token",
+		},
+		{
+			name:           "empty plaintext",
+			plaintext:      "",
+			additionalData: "grant456",
+			usage:          "refresh_token",
+		},
+		{
+			name:           "empty additional data",
+			plaintext:      "secret data",
+			additionalData: "",
+			usage:          "authorization_code",
+		},
+		{
+			name:           "unicode text",
+			plaintext:      "Hello, 世界! 🌍",
+			additionalData: "grant789",
+			usage:          "id_token",
+		},
+		{
+			name:           "long text",
+			plaintext:      "This is a very long piece of text that should be encrypted and decrypted properly. It contains multiple sentences and should test the encryption/decryption functionality thoroughly.",
+			additionalData: "grant-long",
+			usage:          "device_code",
+		},
+		{
+			name:           "empty usage",
+			plaintext:      "test data",
+			additionalData: "grant-empty-usage",
+			usage:          "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test workflow 1: NewToken -> Encrypt -> Decrypt
+			t.Run("new_token_workflow", func(t *testing.T) {
+				// Create a new token
+				token := New(tt.usage)
+
+				// Verify token structure
+				if token.User() == "" {
+					t.Error("User field should not be empty")
+				}
+				if token.Stored() == nil || len(token.Stored()) == 0 {
+					t.Error("Stored field should not be empty")
+				}
+				if len(token.encryption) != keyLength {
+					t.Errorf("Encryption key should be %d bytes, got %d", keyLength, len(token.encryption))
+				}
+
+				// Verify tokens are valid base64
+				_, err := base64.URLEncoding.DecodeString(token.User())
+				if err != nil {
+					t.Errorf("User token should be valid base64: %v", err)
+				}
+
+				// Encrypt data
+				encrypted, err := token.Encrypt(tt.plaintext, tt.additionalData)
+				if err != nil {
+					t.Errorf("Encrypt failed: %v", err)
+					return
+				}
+
+				// Verify encrypted data is different from plaintext
+				if string(encrypted) == tt.plaintext {
+					t.Error("Encrypted data should not match plaintext")
+				}
+
+				// Decrypt data
+				decrypted, err := token.Decrypt(encrypted, tt.additionalData)
+				if err != nil {
+					t.Errorf("Decrypt failed: %v", err)
+					return
+				}
+
+				// Verify decrypted data matches original
+				if string(decrypted) != tt.plaintext {
+					t.Errorf("Decrypted data doesn't match original. Got %q, want %q", string(decrypted), tt.plaintext)
+				}
+			})
+
+			// Test workflow 2: NewToken -> TokenFromUserToken -> Cross-encrypt/decrypt
+			t.Run("derived_token_workflow", func(t *testing.T) {
+				// Create original token
+				originalToken := New(tt.usage)
+
+				// Derive token from user token
+				derivedToken, err := FromUserToken(originalToken.User(), tt.usage)
+				if err != nil {
+					t.Errorf("FromUserToken failed: %v", err)
+					return
+				}
+
+				// Verify derived token matches original
+				if derivedToken.User() != originalToken.User() {
+					t.Error("Derived token User should match original")
+				}
+				if len(derivedToken.Stored()) != len(originalToken.Stored()) {
+					t.Error("Derived token Stored length should match original")
+				}
+				for i := range derivedToken.Stored() {
+					if derivedToken.Stored()[i] != originalToken.Stored()[i] {
+						t.Error("Derived token Stored should match original")
+						break
+					}
+				}
+				if len(derivedToken.encryption) != len(originalToken.encryption) {
+					t.Error("Derived token Encryption key length should match original")
+				}
+				for i := range derivedToken.encryption {
+					if derivedToken.encryption[i] != originalToken.encryption[i] {
+						t.Error("Derived token Encryption key should match original")
+						break
+					}
+				}
+
+				// Encrypt with derived token
+				encrypted, err := derivedToken.Encrypt(tt.plaintext, tt.additionalData)
+				if err != nil {
+					t.Errorf("Encrypt with derived token failed: %v", err)
+					return
+				}
+
+				// Decrypt with original token
+				decrypted, err := originalToken.Decrypt(encrypted, tt.additionalData)
+				if err != nil {
+					t.Errorf("Decrypt with original token failed: %v", err)
+					return
+				}
+
+				// Verify decrypted data matches original
+				if string(decrypted) != tt.plaintext {
+					t.Errorf("Decrypted data doesn't match original. Got %q, want %q", string(decrypted), tt.plaintext)
+				}
+
+				// Test reverse: encrypt with original, decrypt with derived
+				encrypted2, err := originalToken.Encrypt(tt.plaintext, tt.additionalData)
+				if err != nil {
+					t.Errorf("Encrypt with original token failed: %v", err)
+					return
+				}
+
+				decrypted2, err := derivedToken.Decrypt(encrypted2, tt.additionalData)
+				if err != nil {
+					t.Errorf("Decrypt with derived token failed: %v", err)
+					return
+				}
+
+				if string(decrypted2) != tt.plaintext {
+					t.Errorf("Reverse decrypted data doesn't match original. Got %q, want %q", string(decrypted2), tt.plaintext)
+				}
+			})
+		})
+	}
+}
+
+// TestUsageDomainSeparation tests that different usage values create different tokens
+func TestUsageDomainSeparation(t *testing.T) {
+	plaintext := "test data"
+	additionalData := "grant123"
+
+	// Create tokens with different usage values
+	token1 := New("access_token")
+	token2 := New("refresh_token")
+	token3 := New("authorization_code")
+
+	// Verify that different usage values produce different tokens
+	if token1.User() == token2.User() {
+		t.Error("Tokens with different usage should have different user tokens")
+	}
+	if token1.User() == token3.User() {
+		t.Error("Tokens with different usage should have different user tokens")
+	}
+	if token2.User() == token3.User() {
+		t.Error("Tokens with different usage should have different user tokens")
+	}
+
+	// Test that tokens with different usage cannot decrypt each other's data
+	encrypted1, err := token1.Encrypt(plaintext, additionalData)
+	if err != nil {
+		t.Fatalf("Encrypt with token1 failed: %v", err)
+	}
+
+	encrypted2, err := token2.Encrypt(plaintext, additionalData)
+	if err != nil {
+		t.Fatalf("Encrypt with token2 failed: %v", err)
+	}
+
+	// Token2 should not be able to decrypt token1's data
+	_, err = token2.Decrypt(encrypted1, additionalData)
+	if err == nil {
+		t.Error("Token2 should not be able to decrypt token1's data")
+	}
+
+	// Token1 should not be able to decrypt token2's data
+	_, err = token1.Decrypt(encrypted2, additionalData)
+	if err == nil {
+		t.Error("Token1 should not be able to decrypt token2's data")
+	}
+
+	// Test that derived tokens with correct usage can decrypt original data
+	derivedToken1, err := FromUserToken(token1.User(), "access_token")
+	if err != nil {
+		t.Fatalf("FromUserToken failed: %v", err)
+	}
+
+	decrypted, err := derivedToken1.Decrypt(encrypted1, additionalData)
+	if err != nil {
+		t.Errorf("Derived token should be able to decrypt original data: %v", err)
+	}
+	if string(decrypted) != plaintext {
+		t.Errorf("Decrypted data doesn't match original. Got %q, want %q", string(decrypted), plaintext)
+	}
+}
+
+// TestUsageMismatch tests that using different usage when deriving tokens creates different tokens
+func TestUsageMismatch(t *testing.T) {
+	// Create a token with one usage
+	originalToken := New("access_token")
+
+	// Derive with different usage - this should work but create a different token
+	derivedTokenWrong, err := FromUserToken(originalToken.User(), "refresh_token")
+	if err != nil {
+		t.Errorf("Deriving token with different usage should work: %v", err)
+	}
+
+	// Derive with empty usage - this should also work
+	derivedTokenEmpty, err := FromUserToken(originalToken.User(), "")
+	if err != nil {
+		t.Errorf("Deriving token with empty usage should work: %v", err)
+	}
+
+	// Verify that different usage creates different tokens
+	if derivedTokenWrong.User() != originalToken.User() {
+		t.Error("User field should always match regardless of usage")
+	}
+	if derivedTokenEmpty.User() != originalToken.User() {
+		t.Error("User field should always match regardless of usage")
+	}
+
+	// But the stored and encryption keys should be different
+	if len(derivedTokenWrong.Stored()) == len(originalToken.Stored()) {
+		same := true
+		for i := range derivedTokenWrong.Stored() {
+			if derivedTokenWrong.Stored()[i] != originalToken.Stored()[i] {
+				same = false
+				break
+			}
+		}
+		if same {
+			t.Error("Tokens with different usage should have different stored tokens")
+		}
+	}
+
+	if len(derivedTokenEmpty.Stored()) == len(originalToken.Stored()) {
+		same := true
+		for i := range derivedTokenEmpty.Stored() {
+			if derivedTokenEmpty.Stored()[i] != originalToken.Stored()[i] {
+				same = false
+				break
+			}
+		}
+		if same {
+			t.Error("Tokens with empty usage should have different stored tokens")
+		}
+	}
+
+	// Verify that correct usage works and matches original
+	derivedTokenCorrect, err := FromUserToken(originalToken.User(), "access_token")
+	if err != nil {
+		t.Errorf("Deriving token with correct usage should work: %v", err)
+	}
+
+	// Verify derived token matches original
+	if derivedTokenCorrect.User() != originalToken.User() {
+		t.Error("Derived token User should match original")
+	}
+
+	// Test that tokens with different usage cannot decrypt each other's data
+	plaintext := "test data"
+	additionalData := "grant123"
+
+	encryptedOriginal, err := originalToken.Encrypt(plaintext, additionalData)
+	if err != nil {
+		t.Fatalf("Encrypt with original token failed: %v", err)
+	}
+
+	// Wrong usage token should not be able to decrypt original's data
+	_, err = derivedTokenWrong.Decrypt(encryptedOriginal, additionalData)
+	if err == nil {
+		t.Error("Token with wrong usage should not be able to decrypt original's data")
+	}
+
+	// Empty usage token should not be able to decrypt original's data
+	_, err = derivedTokenEmpty.Decrypt(encryptedOriginal, additionalData)
+	if err == nil {
+		t.Error("Token with empty usage should not be able to decrypt original's data")
+	}
+
+	// Correct usage token should be able to decrypt original's data
+	decrypted, err := derivedTokenCorrect.Decrypt(encryptedOriginal, additionalData)
+	if err != nil {
+		t.Errorf("Token with correct usage should be able to decrypt original's data: %v", err)
+	}
+	if string(decrypted) != plaintext {
+		t.Errorf("Decrypted data doesn't match original. Got %q, want %q", string(decrypted), plaintext)
+	}
+}
+
+func TestTokenErrorCases(t *testing.T) {
+	tests := []struct {
+		name           string
+		userToken      string
+		usage          string
+		plaintext      string
+		additionalData string
+		wantErr        bool
+	}{
+		{
+			name:           "invalid base64 user token",
+			userToken:      "invalid-base64!",
+			usage:          "access_token",
+			plaintext:      "test",
+			additionalData: "grant",
+			wantErr:        true,
+		},
+		{
+			name:           "valid user token",
+			userToken:      New("access_token").User(),
+			usage:          "access_token",
+			plaintext:      "test",
+			additionalData: "grant",
+			wantErr:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := FromUserToken(tt.userToken, tt.usage)
+			if tt.wantErr && err == nil {
+				t.Error("expected error but got none")
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestEncryptionErrorCases(t *testing.T) {
+	// Create a valid token
+	token := New("access_token")
+	plaintext := "test data"
+	additionalData := "grant123"
+
+	// Encrypt some data
+	encrypted, err := token.Encrypt(plaintext, additionalData)
+	if err != nil {
+		t.Fatalf("Setup encryption failed: %v", err)
+	}
+
+	tests := []struct {
+		name           string
+		ciphertext     []byte
+		additionalData string
+		wantErr        bool
+	}{
+		{
+			name:           "wrong additional data",
+			ciphertext:     encrypted,
+			additionalData: "wrong-grant",
+			wantErr:        true,
+		},
+		{
+			name:           "corrupted ciphertext",
+			ciphertext:     append(encrypted[:len(encrypted)-1], 0xFF),
+			additionalData: additionalData,
+			wantErr:        true,
+		},
+		{
+			name:           "too short ciphertext",
+			ciphertext:     []byte{1, 2, 3, 4, 5},
+			additionalData: additionalData,
+			wantErr:        true,
+		},
+		{
+			name:           "empty ciphertext",
+			ciphertext:     []byte{},
+			additionalData: additionalData,
+			wantErr:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := token.Decrypt(tt.ciphertext, tt.additionalData)
+			if tt.wantErr && err == nil {
+				t.Error("expected error but got none")
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestTokenConsistency(t *testing.T) {
+	// Test that the same user token always produces the same derived token
+	originalToken := New("access_token")
+
+	token1, err := FromUserToken(originalToken.User(), "access_token")
+	if err != nil {
+		t.Fatalf("FromUserToken failed: %v", err)
+	}
+
+	token2, err := FromUserToken(originalToken.User(), "access_token")
+	if err != nil {
+		t.Fatalf("FromUserToken failed: %v", err)
+	}
+
+	// Check that both derived tokens are identical
+	if token1.User() != token2.User() {
+		t.Error("User field should be identical")
+	}
+	if len(token1.Stored()) != len(token2.Stored()) {
+		t.Error("Stored field lengths should be identical")
+	}
+	for i := range token1.Stored() {
+		if token1.Stored()[i] != token2.Stored()[i] {
+			t.Error("Stored fields should be identical")
+			break
+		}
+	}
+	if len(token1.encryption) != len(token2.encryption) {
+		t.Error("Encryption key lengths should be identical")
+	}
+	for i := range token1.encryption {
+		if token1.encryption[i] != token2.encryption[i] {
+			t.Error("Encryption keys should be identical")
+			break
+		}
+	}
+
+	// Test that different tokens produce different results
+	token3 := New("access_token")
+	if token1.User() == token3.User() {
+		t.Error("Different tokens should have different user tokens")
+	}
+	if len(token1.Stored()) == len(token3.Stored()) {
+		// Check if stored tokens are actually different
+		same := true
+		for i := range token1.Stored() {
+			if token1.Stored()[i] != token3.Stored()[i] {
+				same = false
+				break
+			}
+		}
+		if same {
+			t.Error("Different tokens should have different stored tokens")
+		}
+	}
+}

--- a/server_test.go
+++ b/server_test.go
@@ -2,7 +2,6 @@ package oauth2as
 
 import (
 	"context"
-	"crypto/rand"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -18,6 +17,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/lstoll/oauth2as/internal/oauth2"
+	"github.com/lstoll/oauth2as/internal/token"
 	"github.com/lstoll/oauth2ext/claims"
 	"github.com/lstoll/oauth2ext/oidc"
 	"github.com/tink-crypto/tink-go/v2/jwt"
@@ -523,8 +523,8 @@ func testKeysets() AlgKeysets {
 }
 
 func newRefreshGrant(t *testing.T, smgr Storage) (refreshToken string) {
-	refreshToken = rand.Text()
-	refreshTokenHash := hashValue(refreshToken)
+	newToken := token.New(tokenUsageRefresh)
+	refreshToken = newToken.User()
 
 	// Create a StoredGrant with the refresh token
 	grant := &StoredGrant{
@@ -532,7 +532,7 @@ func newRefreshGrant(t *testing.T, smgr Storage) (refreshToken string) {
 		UserID:        "testsub",
 		ClientID:      "client-id",
 		GrantedScopes: []string{oidc.ScopeOfflineAccess},
-		RefreshToken:  &refreshTokenHash,
+		RefreshToken:  newToken.Stored(),
 		GrantedAt:     time.Now(),
 		ExpiresAt:     time.Now().Add(60 * time.Minute),
 	}
@@ -545,8 +545,8 @@ func newRefreshGrant(t *testing.T, smgr Storage) (refreshToken string) {
 }
 
 func newCodeGrant(t *testing.T, smgr Storage) (authCode string) {
-	code := rand.Text()
-	codeHash := hashValue(code)
+	newToken := token.New(tokenUsageAuthCode)
+	code := newToken.User()
 
 	// Create a StoredGrant with the auth code
 	grant := &StoredGrant{
@@ -554,7 +554,7 @@ func newCodeGrant(t *testing.T, smgr Storage) (authCode string) {
 		UserID:        "testsub",
 		ClientID:      "client-id",
 		GrantedScopes: []string{oidc.ScopeOfflineAccess},
-		AuthCode:      &codeHash,
+		AuthCode:      newToken.Stored(),
 		GrantedAt:     time.Now(),
 		ExpiresAt:     time.Now().Add(1 * time.Minute),
 	}

--- a/storage.go
+++ b/storage.go
@@ -11,7 +11,7 @@ type StoredGrant struct {
 	// ID is the unique identifier for this grant.
 	ID uuid.UUID
 	// AuthCode is the authorization code for the initial token exchange.
-	AuthCode *string
+	AuthCode []byte
 	// UserID is the user ID that was granted access.
 	UserID string
 	// ClientID is the client ID that was granted access.
@@ -22,11 +22,17 @@ type StoredGrant struct {
 	// finalizing the code flow.
 	Request *AuthRequest
 	// RefreshToken is the refresh token for the grant.
-	RefreshToken *string
+	RefreshToken []byte
 	// GrantedAt is the time at which the grant was granted.
 	GrantedAt time.Time
 	// ExpiresAt is the time at which the grant will expire.
 	ExpiresAt time.Time
+
+	// Metadata is arbitrary metadata that can be stored with the grant.
+	Metadata map[string]string
+	// EncryptedMetadata stores the encrypted metadata associated with this
+	// grant.
+	EncryptedMetadata []byte
 
 	// TODO -acr, AMR etc.
 }
@@ -43,9 +49,9 @@ type Storage interface {
 	// a nil grant.
 	GetGrant(ctx context.Context, id uuid.UUID) (*StoredGrant, error)
 	// GetGrantByAuthCode retrieves a grant by authorization code. If no grant
-	// is found, it should return a nil grant.
-	GetGrantByAuthCode(ctx context.Context, authCode string) (*StoredGrant, error)
+	// is found, it should return a nil grant. The code is a raw byte slice.
+	GetGrantByAuthCode(ctx context.Context, authCode []byte) (*StoredGrant, error)
 	// GetGrantByRefreshToken retrieves a grant by refresh token. If no grant
-	// is found, it should return a nil grant.
-	GetGrantByRefreshToken(ctx context.Context, refreshToken string) (*StoredGrant, error)
+	// is found, it should return a nil grant. The token is a raw byte slice.
+	GetGrantByRefreshToken(ctx context.Context, refreshToken []byte) (*StoredGrant, error)
 }


### PR DESCRIPTION
Rather than rand.text, use our own token system. This is extended with the ability to encrypt/decrypt data against a given token. Uses hkdf with a fixed seed to give a little bit more use separation than straight SHA256.

Grant/storage extended to persist metadata about a grant, as well as encrypted metadata that is only accessible when a user presents their token.