### PR TITLE
Support multi-algorithm signers

### DIFF
--- a/client.go
+++ b/client.go
@@ -5,14 +5,27 @@ import (
 	"net/url"
 )
 
+type clientOpts struct {
+	skipPKCE   bool
+	signingAlg SigningAlg
+}
+
 // ClientOpt is a flag that can be set on a given client, to adjust various
 // behaviours.
-type ClientOpt string
+type ClientOpt func(opts *clientOpts)
 
-const (
-	// ClientOptSkipPKCE indicates that the client is not required to use PKCE
-	ClientOptSkipPKCE ClientOpt = "skip-pkce"
-)
+// ClientOptSkipPKCE indicates that the client is not required to use PKCE
+func ClientOptSkipPKCE() ClientOpt {
+	return func(opts *clientOpts) {
+		opts.skipPKCE = true
+	}
+}
+
+func ClientOptSigningAlg(alg SigningAlg) ClientOpt {
+	return func(opts *clientOpts) {
+		opts.signingAlg = alg
+	}
+}
 
 // ClientSource is used for validating client informantion for the general flow
 type ClientSource interface {

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -80,11 +80,11 @@ func TestE2E(t *testing.T) {
 					Secrets:      []string{clientSecret},
 					RedirectURLs: []string{cliSvr.URL},
 					Public:       tc.WithPKCE,
-					Opts:         []oauth2as.ClientOpt{oauth2as.ClientOptSkipPKCE},
+					Opts:         []oauth2as.ClientOpt{oauth2as.ClientOptSkipPKCE()},
 				},
 			}
 			if !tc.WithPKCE {
-				clientSource[0].Opts = []oauth2as.ClientOpt{oauth2as.ClientOptSkipPKCE}
+				clientSource[0].Opts = []oauth2as.ClientOpt{oauth2as.ClientOptSkipPKCE()}
 			}
 
 			s := oauth2as.NewMemStorage()


### PR DESCRIPTION
Wire up, via a client option, the ability for per-client JWT signing algorithm support.

Client Options are extended to be functional, to allow passing options via them.